### PR TITLE
Attemp to use js-sys for JsValue Err, and console_error_panic_hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,9 +571,11 @@ version = "0.1.1"
 dependencies = [
  "base36 0.0.0 (git+https://github.com/transumption-unstable/base36?rev=4e6981e13ec5f3748dfe9b8870aa4e8ed749096d)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hpos-config-core 0.0.0 (git+https://github.com/Holo-Host/hpos-config?branch=develop)",
+ "js-sys 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/CONTRIBUTING.md
+++ b/client/CONTRIBUTING.md
@@ -20,7 +20,7 @@ cargo test
 ### Wasm-pack unit tests
 Test interaction with created Wasm package in selected environments:
 ```
-wasm-pack --firefox
+wasm-pack test --firefox
 ```
 Must specify at least one of `--node`, `--chrome`, `--firefox`, or `--safari`.
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -10,9 +10,11 @@ repository = "https://github.com/Holo-Host/hp-admin-crypto"
 [dependencies]
 base36 = { git = "https://github.com/transumption-unstable/base36", rev = "4e6981e13ec5f3748dfe9b8870aa4e8ed749096d"}
 base64 = "0.10.1"
+console_error_panic_hook = "0.1.6"
 ed25519-dalek = { version = "1.0.0-pre.2", features = ["nightly", "serde"] }
 failure = "0.1.5"
 hpos-config-core = { git = "https://github.com/Holo-Host/hpos-config", branch = "develop" }
+js-sys = "0.3.30"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.39"
 wasm-bindgen = { version = "0.2.51", features = ["serde-serialize"] }

--- a/client/README.md
+++ b/client/README.md
@@ -20,7 +20,7 @@ let kp = new HpAdminKeypair(HC_PUBLIC_KEY, EMAIL, PASSWORD);
 const payload = {
     method: "get",
     uri: "/someuri",
-    body_string: ""
+    body: ""
 }
 
 console.log(kp.sign(payload));

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -13,7 +13,7 @@ pub struct HpAdminKeypair(Keypair);
 struct Payload {
     method: String,
     uri: String,
-    body_string: String,
+    body: String,
 }
 
 #[wasm_bindgen]
@@ -27,7 +27,7 @@ impl HpAdminKeypair {
         email: String,
         password: String,
     ) -> Fallible<HpAdminKeypair> {
-        console_error_panic_hook::set_once();
+        // console_error_panic_hook::set_once();
         let keypair = new_inner(hc_public_key_string, email, password)?;
         Ok(Self(keypair))
     }
@@ -37,14 +37,14 @@ impl HpAdminKeypair {
     /// const payload = {
     ///     method: String,
     ///     uri: String,
-    ///     body_string: String
+    ///     body: String
     /// }
     /// @example
     /// myKeys = new HpAdminKeypair( hc_public_key_string, email, password );
     /// const payload = {
     ///     method: "get",
     ///     uri: "/someuri",
-    ///     body_string: ""
+    ///     body: ""
     /// }
     /// myKeys.sign( payload );
     #[wasm_bindgen]
@@ -139,7 +139,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             uri: "/someuri".to_string(),
-            body_string: "".to_string(),
+            body: "".to_string(),
         };
 
         let payload_js = JsValue::from_serde(&payload).unwrap();
@@ -159,7 +159,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             uri: "/someuri".to_string(),
-            body_string: "".to_string(),
+            body: "".to_string(),
         };
         let payload_js = JsValue::from_serde(&payload).unwrap();
         let my_keypair = HpAdminKeypair::new(

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,5 +1,7 @@
+pub mod util;
+
+use crate::util::*;
 use ed25519_dalek::{Keypair, PublicKey};
-use failure::{err_msg, Error};
 use hpos_config_core::admin_keypair_from;
 use serde::*;
 use wasm_bindgen::prelude::*;
@@ -24,12 +26,10 @@ impl HpAdminKeypair {
         hc_public_key_string: String,
         email: String,
         password: String,
-    ) -> Result<HpAdminKeypair, JsValue> {
-        // rewrite any Error into JsValue
-        match new_inner(hc_public_key_string, email, password) {
-            Ok(v) => Ok(Self(v)),
-            Err(e) => Err(e.to_string().into()),
-        }
+    ) -> Fallible<HpAdminKeypair> {
+        console_error_panic_hook::set_once();
+        let keypair = new_inner(hc_public_key_string, email, password)?;
+        Ok(Self(keypair))
     }
 
     /// @description Sign payload and return base64 encoded signature.
@@ -48,17 +48,9 @@ impl HpAdminKeypair {
     /// }
     /// myKeys.sign( payload );
     #[wasm_bindgen]
-    pub fn sign(&self, payload: &JsValue) -> Result<String, JsValue> {
+    pub fn sign(&self, payload: &JsValue) -> Fallible<String> {
         // return meaningful error message via JsValue
-        let payload_vec = match parse_payload(payload) {
-            Ok(v) => v,
-            Err(_) => {
-                return Err("Malformed signing payload, check docs for details."
-                    .to_string()
-                    .into())
-            }
-        };
-
+        let payload_vec = parse_payload(payload)?;
         let signature = self.0.sign(&payload_vec);
         Ok(base64::encode_config(
             &signature.to_bytes()[..],
@@ -71,18 +63,21 @@ fn new_inner(
     hc_public_key_string: String,
     email: String,
     password: String,
-) -> Result<Keypair, Error> {
-    let hc_public_key_bytes = base36::decode(&hc_public_key_string)?;
-    let hc_public_key = PublicKey::from_bytes(&hc_public_key_bytes)?;
-    Ok(admin_keypair_from(hc_public_key, &email, &password)?)
+) -> Fallible<Keypair> {
+    let hc_public_key_bytes = base36::decode(&hc_public_key_string)
+        .map_err(|e| JsValue::from(e.to_string()))?;
+    let hc_public_key = PublicKey::from_bytes(&hc_public_key_bytes)
+        .map_err(into_js_error)?;
+    let keypair = admin_keypair_from(hc_public_key, &email, &password)
+       .map_err(|e| JsValue::from(e.to_string()))?;
+    Ok(keypair)
 }
 
-fn parse_payload(payload: &JsValue) -> Result<Vec<u8>, Error> {
-    let payload_struct: Payload = payload.into_serde()?;
-    match serde_json::to_vec(&payload_struct) {
-        Ok(v) => Ok(v),
-        Err(e) => Err(err_msg(e.to_string())),
-    }
+fn parse_payload(payload: &JsValue) -> Fallible<Vec<u8>> {
+    let payload_struct: Payload = payload.into_serde()
+        .map_err(into_js_error)?;
+    Ok(serde_json::to_vec(&payload_struct)
+       .map_err(into_js_error)?)
 }
 
 #[cfg(test)]

--- a/client/src/util.rs
+++ b/client/src/util.rs
@@ -1,0 +1,8 @@
+use failure::*;
+use wasm_bindgen::prelude::*;
+
+pub type Fallible<T> = Result<T, JsValue>;
+
+pub fn into_js_error(err: impl Fail) -> JsValue {
+    js_sys::Error::new(&err.to_string()).into()
+}

--- a/client/tests/www/index.js
+++ b/client/tests/www/index.js
@@ -1,4 +1,4 @@
-import { HpAdminKeypair } from "@holo-host/hp-admin-key-manager";
+import { HpAdminKeypair } from "../../pkg/hp_admin_key_manager";
 
 const HC_PUBLIC_KEY = "3llrdmlase6xwo9drzs6qpze40hgaucyf7g8xpjze6dz32s957";
 const EMAIL = "pj@abba.pl";
@@ -8,8 +8,8 @@ let kp = new HpAdminKeypair(HC_PUBLIC_KEY, EMAIL, PASSWORD);
 
 const payload = {
     method: "get",
-    uri: "/someuri",
-    body_string: ""
+    uri: 1,
+    body: ""
 }
 
 console.log(kp.sign(payload));

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -29,7 +29,7 @@ lazy_static! {
 struct Payload {
     method: String,
     uri: String,
-    body_string: String,
+    body: String,
 }
 
 // Create response based on the request parameters
@@ -62,7 +62,7 @@ fn create_response(req: Request<Body>) -> impl Future<Item = Response<Body>, Err
                     req_uri_string
                 );
 
-                let body_string = match String::from_utf8(body.to_vec()) {
+                let body = match String::from_utf8(body.to_vec()) {
                     Ok(s) => s,
                     Err(e) => {
                         debug!("Error parsing request body: {}", e);
@@ -73,7 +73,7 @@ fn create_response(req: Request<Body>) -> impl Future<Item = Response<Body>, Err
                 let payload = Payload {
                     method: parts.method.to_string(),
                     uri: req_uri_string,
-                    body_string: body_string,
+                    body: body,
                 };
 
                 let public_key = match read_hp_pubkey() {
@@ -220,7 +220,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             uri: "/abba".to_string(),
-            body_string: "\"something\": \"interesting\"".to_string(),
+            body: "\"something\": \"interesting\"".to_string(),
         };
 
         let signature = secret_key_exp.sign(&serde_json::to_vec(&payload).unwrap(), &public_key);
@@ -247,7 +247,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             uri: "/abba".to_string(),
-            body_string: "\"something\": \"interesting\"".to_string(),
+            body: "\"something\": \"interesting\"".to_string(),
         };
 
         let mut headers = HeaderMap::new();


### PR DESCRIPTION
I tried to apply `into_js_error` (clumsily), to manage JsValue Err Result.

 - Loses any kind of diagnostic descriptive error on bad payload.
   -  A generic JSON parsing failure message that doesn't identify the payload is basically worthless, for diagnostic purposes.
 - This doesn't appear to be an improvement, to me...
   - I must be missing a more Rust-y way of applying this to various Err results.
 - The `console_error_panic_hook` is purported to be valuable, but I have not tested it.

This compiles and passes (the minimal) Rust and Javascript unit tests in `nix-shell --run 'make test'`.

I'm leaning toward discarding this pull and leaving it the way it is?