### PR TITLE
Read X-Holo-Admin-Signature from query param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,11 +563,12 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "hp-admin-keypair"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base36 0.0.0 (git+https://github.com/transumption-unstable/base36?rev=4e6981e13ec5f3748dfe9b8870aa4e8ed749096d)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hp-admin-keypair"
-version = "0.1.2"
+version = "0.1.3"
 description = "Client side package for signing API calls to HPOS Admin"
 authors = ["PJ <pj@imagine-nyc.com>"]
 license = "MIT"

--- a/client/README.md
+++ b/client/README.md
@@ -18,9 +18,9 @@ const PASSWORD = "abba";
 let kp = new HpAdminKeypair(HC_PUBLIC_KEY, EMAIL, PASSWORD);
 
 const payload = {
-    method: "get",
-    request: "/someuri",
-    body: ""
+    method: "get",          // String
+    request: "/someuri",    // String
+    body: "somebody"        // String || undefined
 }
 
 console.log(kp.sign(payload));

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -13,7 +13,7 @@ pub struct HpAdminKeypair(Keypair);
 struct Payload {
     method: String,
     request: String,
-    body: String,
+    body: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -82,7 +82,7 @@ mod tests {
     const EMAIL: &str = "pj@abba.pl";
     const PASSWORD: &str = "abba";
     const EXPECTED_SIGNATURE: &str =
-        "b1QKomb7z1/W6gb0bNwc85OhdZED71NFenkCg5xBFFwSYEFJnqo/jcNn3RZbPPJwTBSN5bTEt0jCI1wtvDTGCQ";
+        "EHl16e8ZRMhVk1BpvPxuc8PDCNUcZfWPDgU+GuOVX5r2SNzzwSK4WAXC8+Hc0lF2JpDcxMTEHVCp3KNAd4zlAA";
     const WRONG_SIGNATURE: &str =
         "dQlFxqMQh0idWk6anOerf7b9/XssKkvSrVIv9gMuf7M31ivli6BM2ktCsv9FHB/2FfdwO4LS8muOkFjSt7uAAg";
     const EXPECTED_KEYPAIR_BYTES: [u8; 64] = [
@@ -129,7 +129,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             request: "/someuri".to_string(),
-            body: "".to_string(),
+            body: None,
         };
 
         let payload_js = JsValue::from_serde(&payload).unwrap();
@@ -149,7 +149,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             request: "/someuri".to_string(),
-            body: "".to_string(),
+            body: Some("".to_string()),
         };
         let payload_js = JsValue::from_serde(&payload).unwrap();
         let my_keypair = HpAdminKeypair::new(
@@ -169,10 +169,12 @@ mod tests {
         struct PayloadErr {
             method: String,
             request: String,
+            body: u8
         }
         let payload_err = PayloadErr {
             method: "get".to_string(),
             request: "/someuri".to_string(),
+            body: 1
         };
 
         let payload_err_js = JsValue::from_serde(&payload_err).unwrap();

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -37,14 +37,14 @@ impl HpAdminKeypair {
     /// const payload = {
     ///     method: String,
     ///     request: String,
-    ///     body: String
+    ///     body: String || undefined
     /// }
     /// @example
     /// myKeys = new HpAdminKeypair( hc_public_key_string, email, password );
     /// const payload = {
     ///     method: "get",
     ///     request: "/someuri",
-    ///     body: ""
+    ///     body: "/somebody"
     /// }
     /// myKeys.sign( payload );
     #[wasm_bindgen]

--- a/client/tests/www/index.js
+++ b/client/tests/www/index.js
@@ -1,4 +1,4 @@
-import { HpAdminKeypair } from "@holo-host/hp-admin-keypair";
+import { HpAdminKeypair } from "../../pkg";
 
 const HC_PUBLIC_KEY = "3llrdmlase6xwo9drzs6qpze40hgaucyf7g8xpjze6dz32s957";
 const EMAIL = "pj@abba.pl";
@@ -9,7 +9,7 @@ let kp = new HpAdminKeypair(HC_PUBLIC_KEY, EMAIL, PASSWORD);
 const payload = {
     method: "get",
     request: "/someuri",
-    body: ""
+    body: undefined
 }
 
 console.log(kp.sign(payload));

--- a/client/tests/www/package.json
+++ b/client/tests/www/package.json
@@ -9,7 +9,7 @@
   },
   "author": "PJ Klimek <pj@imagine-nyc.com>",
   "dependencies": {
-    "@holo-host/hp-admin-keypair": "^0.1.2"
+    "@holo-host/hp-admin-keypair": "^0.1.3"
   },
   "devDependencies": {
     "webpack": "^4.29.3",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,3 +17,4 @@ lazy_static = "1.2"
 log = "0.4.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.39"
+url = "2.1.0"

--- a/server/README.md
+++ b/server/README.md
@@ -4,12 +4,14 @@ Server is listening on loopback address `http://127.0.0.1:2884/` for incoming ht
 - x-hpos-admin-signature
 - x-original-uri
 
-Based on their value service verifies if the signature and `HP Admin key` match the content:
+In the absence of the x-hpos-admin-signature header server is looking for a query parameter `X-Holo-Admin-Signature` (both key and value case-sensitive) and uses a value for signature.
+
+Based on their x-original-uri and signature service verifies if the signature and `HP Admin key` match the content:
 ```
 {
   "method": ${verb}, // to lowercase, eg. "get"
   "request": ${URI with arguments}, // case sensitive, eg. "/api/v1/config?a=b"
-  "body": ${body} // case sensitive, eg. "{\"name\": \"My HoloPort Name\"}"
+  "body": ${body} // case sensitive, for empty body can be set to js `undefined`, eg. "{\"name\": \"My HoloPort Name\"}"
 }
 ```
 The value of `HP Admin Key` is read from the file located via environmental variable `HPOS_STATE_PATH`.

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -63,8 +63,14 @@ fn create_response(req: Request<Body>) -> impl Future<Item = Response<Body>, Err
                     req_uri_string
                 );
 
-                let body = match String::from_utf8(body.to_vec()) {
-                    Ok(s) => s,
+                let body_option = match String::from_utf8(body.to_vec()) {
+                    Ok(s) => {
+                        if s == "" {
+                            None
+                        } else {
+                            Some(s)
+                        }
+                    },
                     Err(e) => {
                         debug!("Error parsing request body: {}", e);
                         return respond_success(false);
@@ -74,7 +80,7 @@ fn create_response(req: Request<Body>) -> impl Future<Item = Response<Body>, Err
                 let payload = Payload {
                     method: parts.method.to_string(),
                     request: req_uri_string,
-                    body: Some(body),
+                    body: body_option,
                 };
 
                 let public_key = match read_hp_pubkey() {

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -29,7 +29,7 @@ lazy_static! {
 struct Payload {
     method: String,
     request: String,
-    body: String,
+    body: Option<String>,
 }
 
 // Create response based on the request parameters
@@ -73,7 +73,7 @@ fn create_response(req: Request<Body>) -> impl Future<Item = Response<Body>, Err
                 let payload = Payload {
                     method: parts.method.to_string(),
                     request: req_uri_string,
-                    body: body,
+                    body: Some(body),
                 };
 
                 let public_key = match read_hp_pubkey() {
@@ -211,7 +211,7 @@ mod tests {
     #[test]
     fn verify_signature_match_client() {
         let expected_signature: &str =
-            "b1QKomb7z1/W6gb0bNwc85OhdZED71NFenkCg5xBFFwSYEFJnqo/jcNn3RZbPPJwTBSN5bTEt0jCI1wtvDTGCQ";
+            "EHl16e8ZRMhVk1BpvPxuc8PDCNUcZfWPDgU+GuOVX5r2SNzzwSK4WAXC8+Hc0lF2JpDcxMTEHVCp3KNAd4zlAA";
         let secret: [u8; 32] = [
             82, 253, 185, 87, 98, 217, 46, 233, 252, 159, 103, 182, 121, 229, 22, 25, 34, 216, 81,
             60, 31, 204, 200, 63, 63, 233, 220, 47, 221, 74, 86, 129,
@@ -224,7 +224,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             request: "/someuri".to_string(),
-            body: "".to_string(),
+            body: None,
         };
 
         let signature = secret_key_exp.sign(&serde_json::to_vec(&payload).unwrap(), &public_key);
@@ -250,7 +250,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             request: "/someuri".to_string(),
-            body: "".to_string(),
+            body: Some("\"a:\"b\"\"".to_string()),
         };
 
         let signature = secret_key_exp.sign(&serde_json::to_vec(&payload).unwrap(), &public_key);
@@ -277,7 +277,7 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             request: "/someuri".to_string(),
-            body: "".to_string(),
+            body: None
         };
 
         let mut headers = HeaderMap::new();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -6,6 +6,7 @@ use futures::{
 };
 use hyper::header::{HeaderMap, HeaderName, HeaderValue};
 use hyper::{service, Body, Request, Response, Server, StatusCode};
+use url::form_urlencoded;
 
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -84,7 +85,15 @@ fn create_response(req: Request<Body>) -> impl Future<Item = Response<Body>, Err
                     }
                 };
 
-                let is_verified = match verify_request(payload, parts.headers, public_key) {
+                let signature = match extract_signature(parts.headers, parts.uri.query()) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        debug!("Error while extracting signature: {}", e);
+                        return respond_success(false);
+                    }
+                };
+
+                let is_verified = match verify_request(payload, signature, public_key) {
                     Ok(b) => b,
                     Err(e) => {
                         debug!("Error while verifying signature: {}", e);
@@ -104,21 +113,40 @@ fn create_response(req: Request<Body>) -> impl Future<Item = Response<Body>, Err
     }
 }
 
+fn extract_signature(
+    headers: HeaderMap<HeaderValue>,
+    query_opt: Option<&str>,
+) -> Result<String, Box<dyn Error>> {
+    if let Some(signature) = headers.get(&*X_HPOS_ADMIN_SIGNATURE) {
+        return Ok(signature.to_str()?.to_string());
+    }
+
+    if let Some(query_str) = query_opt {
+        let args = form_urlencoded::parse(query_str.as_bytes()).into_owned();
+
+        for arg in args {
+            let (a, b) = arg;
+            if a == "X-Holo-Admin-Signature".to_string() {
+                return Ok(b);
+            }
+        }
+    }
+
+    Err("Can't read signature from Headers or query string X-Holo-Admin-Signature")?
+}
+
 fn verify_request(
     payload: Payload,
-    headers: HeaderMap<HeaderValue>,
+    signature: String,
     public_key: PublicKey,
 ) -> Result<bool, Box<dyn Error>> {
     let payload_vec = serde_json::to_vec(&payload)?;
 
-    if let Some(signature_base64) = headers.get(&*X_HPOS_ADMIN_SIGNATURE) {
-        if let Ok(signature_vec) = base64::decode_config(&signature_base64, base64::STANDARD_NO_PAD)
-        {
-            if let Ok(signature_bytes) = Signature::from_bytes(&signature_vec) {
-                if public_key.verify(&payload_vec, &signature_bytes).is_ok() {
-                    debug!("Signature verified successfully");
-                    return Ok(true);
-                }
+    if let Ok(signature_vec) = base64::decode_config(&signature, base64::STANDARD_NO_PAD) {
+        if let Ok(signature_bytes) = Signature::from_bytes(&signature_vec) {
+            if public_key.verify(&payload_vec, &signature_bytes).is_ok() {
+                debug!("Signature verified successfully");
+                return Ok(true);
             }
         }
     }
@@ -208,15 +236,16 @@ mod tests {
     use ed25519_dalek::{self, SECRET_KEY_LENGTH};
     use std::convert::From;
 
+    static EXPECTED_SIGNATURE: &str =
+        "EHl16e8ZRMhVk1BpvPxuc8PDCNUcZfWPDgU+GuOVX5r2SNzzwSK4WAXC8+Hc0lF2JpDcxMTEHVCp3KNAd4zlAA";
+    static SECRET: [u8; 32] = [
+        82, 253, 185, 87, 98, 217, 46, 233, 252, 159, 103, 182, 121, 229, 22, 25, 34, 216, 81, 60,
+        31, 204, 200, 63, 63, 233, 220, 47, 221, 74, 86, 129,
+    ];
+
     #[test]
     fn verify_signature_match_client() {
-        let expected_signature: &str =
-            "EHl16e8ZRMhVk1BpvPxuc8PDCNUcZfWPDgU+GuOVX5r2SNzzwSK4WAXC8+Hc0lF2JpDcxMTEHVCp3KNAd4zlAA";
-        let secret: [u8; 32] = [
-            82, 253, 185, 87, 98, 217, 46, 233, 252, 159, 103, 182, 121, 229, 22, 25, 34, 216, 81,
-            60, 31, 204, 200, 63, 63, 233, 220, 47, 221, 74, 86, 129,
-        ];
-        let secret_key = ed25519_dalek::SecretKey::from_bytes(&secret).unwrap();
+        let secret_key = ed25519_dalek::SecretKey::from_bytes(&SECRET).unwrap();
         let public_key = ed25519_dalek::PublicKey::from(&secret_key);
         let secret_key_exp = ed25519_dalek::ExpandedSecretKey::from(&secret_key);
 
@@ -235,36 +264,61 @@ mod tests {
             &mut signature_base64,
         );
 
-        assert_eq!(signature_base64, expected_signature);
+        assert_eq!(signature_base64, EXPECTED_SIGNATURE);
     }
 
     #[test]
-    fn verify_request_smoke() {
+    fn verify_request_from_header() {
         // Get a legit request_hash signature, agent_id
-        let secret: [u8; 32] = [0_u8; SECRET_KEY_LENGTH];
-        let secret_key = ed25519_dalek::SecretKey::from_bytes(&secret).unwrap();
+        let secret_key = ed25519_dalek::SecretKey::from_bytes(&SECRET).unwrap();
         let public_key = ed25519_dalek::PublicKey::from(&secret_key);
-        let secret_key_exp = ed25519_dalek::ExpandedSecretKey::from(&secret_key);
 
         // Now lets sign some payload
         let payload = Payload {
             method: "get".to_string(),
             request: "/someuri".to_string(),
-            body: Some("\"a:\"b\"\"".to_string()),
+            body: None,
         };
 
-        let signature = secret_key_exp.sign(&serde_json::to_vec(&payload).unwrap(), &public_key);
-        let mut signature_base64 = String::new();
-        base64::encode_config_buf(
-            signature.to_bytes().as_ref(),
-            base64::STANDARD_NO_PAD,
-            &mut signature_base64,
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-hpos-admin-signature",
+            EXPECTED_SIGNATURE.parse().unwrap(),
         );
 
-        let mut headers = HeaderMap::new();
-        headers.insert("x-hpos-admin-signature", signature_base64.parse().unwrap());
+        let signature = extract_signature(headers, None).unwrap();
 
-        assert_eq!(verify_request(payload, headers, public_key).unwrap(), true)
+        assert_eq!(
+            verify_request(payload, signature, public_key).unwrap(),
+            true
+        )
+    }
+
+    #[test]
+    fn verify_request_from_query() {
+        // Get a legit request_hash signature, agent_id
+        let secret_key = ed25519_dalek::SecretKey::from_bytes(&SECRET).unwrap();
+        let public_key = ed25519_dalek::PublicKey::from(&secret_key);
+
+        // Now lets sign some payload
+        let payload = Payload {
+            method: "get".to_string(),
+            request: "/someuri".to_string(),
+            body: None,
+        };
+
+        let headers = HeaderMap::new();
+        let encoded: String = form_urlencoded::Serializer::new(String::new())
+            .append_pair("foo", "bar")
+            .append_pair("X-Holo-Admin-Signature", EXPECTED_SIGNATURE)
+            .finish();
+
+        let signature = extract_signature(headers, Some(&encoded)).unwrap();
+
+        assert_eq!(
+            verify_request(payload, signature, public_key).unwrap(),
+            true
+        )
     }
 
     #[test]
@@ -277,12 +331,17 @@ mod tests {
         let payload = Payload {
             method: "get".to_string(),
             request: "/someuri".to_string(),
-            body: None
+            body: None,
         };
 
         let mut headers = HeaderMap::new();
         headers.insert("x-hpos-admin-signature", "Wrong signature".parse().unwrap());
 
-        assert_eq!(verify_request(payload, headers, public_key).unwrap(), false)
+        let signature = extract_signature(headers, None).unwrap();
+
+        assert_eq!(
+            verify_request(payload, signature, public_key).unwrap(),
+            false
+        )
     }
 }


### PR DESCRIPTION
This PR:
- makes body in payload optional
- server: tries to read query parameter X-Holo-Admin-Signature in absence of the header